### PR TITLE
fix: update deployment branch from main to version-15 in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to Production
 on:
   push:
     branches:
-      - main
+      - version-15
 
 concurrency:
   group: production-deploy
@@ -71,8 +71,8 @@ jobs:
             echo ""
             echo ">>> [2/7] Pulling latest code for ${APP_NAME}..."
             cd "apps/${APP_NAME}"
-            git fetch origin main
-            git reset --hard origin/main
+            git fetch upstream version-15
+            git reset --hard upstream/version-15
             echo "    Commit: $(git rev-parse --short HEAD)"
             echo "    Message: $(git log -1 --pretty=%s)"
             cd "${BENCH_PATH}"


### PR DESCRIPTION
This pull request updates the production deployment workflow to target the `version-15` branch instead of `main`, and adjusts the git commands to fetch and reset from the correct remote and branch. This ensures that deployments are based on the intended release branch.

**Deployment workflow updates:**

* Changed the deployment trigger to run on pushes to the `version-15` branch instead of `main` in `.github/workflows/deploy.yml`.
* Updated the git fetch and reset commands to use the `upstream` remote and `version-15` branch, instead of `origin` and `main`, in the deployment workflow script.