### PR TITLE
Specify environment for health-check job and update .gitignore

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,6 +136,7 @@ jobs:
   health-check:
     name: Post-Deployment Health Check
     runs-on: ubuntu-latest
+    environment: pos.xconsol.com
     needs: deploy
     if: success()
     timeout-minutes: 5

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ frontend/dist-electron/
 # Frappe build artifacts
 xpos/public/dist/
 xpos/public/xpos/
+xpos/public/node_modules/
 xpos/www/xpos.html
 
 # Environment & Secrets — NEVER commit these


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow by specifying the environment for the post-deployment health check job.

- Set the `environment` field to `pos.xconsol.com` for the `health-check` job in `.github/workflows/deploy.yml`.