### PR TITLE
Update Frappe and ERPNext dependencies and optimize items API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,17 +8,8 @@ requires-python = ">=3.10"
 readme = "README.md"
 license = { text = "MIT" }
 dynamic = ["version"]
-keywords = ["frappe", "erpnext", "pos", "point-of-sale", "retail", "offline", "electron", "pwa"]
-classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Framework :: Frappe",
-    "Topic :: Office/Business :: Financial :: Point-Of-Sale",
-]
+keywords = ["frappe", "erpnext", "xpos", "point-of-sale", "retail", "offline", "electron", "pwa"]
+
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
     "python-barcode>=0.15.1",
@@ -40,53 +31,14 @@ build-backend = "flit_core.buildapi"
 # package_name = "~=1.1.0"
 
 [tool.bench.frappe-dependencies]
-frappe = ">=15.100.0,<15.200.0"
-erpnext = ">=15.100.0,<15.200.0"
+frappe = ">=15.0.0,<16.0.0"
 
 [tool.ruff]
 line-length = 110
 target-version = "py310"
 
 [tool.ruff.lint]
-select = [
-    "F",
-    "E",
-    "W",
-    "I",
-    "UP",
-    "B",
-    "RUF",
-]
-ignore = [
-    "B007", # loop control variable not used in loop body
-    "B017", # assertRaises(Exception) - should be more specific
-    "B018", # useless expression, not assigned to anything
-    "B023", # function doesn't bind loop variable - will have last iteration's value
-    "B904", # raise inside except without from
-    "C901", # function is too complex
-    "E101", # indentation contains mixed spaces and tabs
-    "E402", # module level import not at top of file
-    "E501", # line too long
-    "E741", # ambiguous variable name
-    "F401", # "unused" imports
-    "F403", # can't detect undefined names from * import
-    "F405", # can't detect undefined names from * import
-    "F722", # syntax error in forward type annotation
-    "F811", # redefinition of unused name
-    "F821", # undefined name — false positives in Frappe DF.Literal annotations
-    "F823", # local variable referenced before assignment — _ is Frappe translation fn
-    "F841", # local variable assigned but never used
-    "RUF003", # ambiguous unicode in comments (e.g. EN DASH)
-    "RUF005", # list concatenation — prefer explicit form
-    "UP030", # use implicit format field references
-    "UP035", # deprecated typing imports (Dict/List/Tuple) — kept for clarity
-    "UP038", # use X | Y in isinstance — keep tuple form for readability
-    "W191", # indentation contains tabs
-]
-
-[tool.ruff.lint.per-file-ignores]
-"**/tests/**" = ["F841", "RUF005"]
-"**/test_*.py" = ["F841", "RUF005"]
+typing-modules = ["frappe.types.DF"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ build-backend = "flit_core.buildapi"
 # package_name = "~=1.1.0"
 
 [tool.bench.frappe-dependencies]
-frappe = ">=15.40.4,<16.0.0"
-erpnext = ">=15.40.4,<16.0.0"
+frappe = ">=15.100.0,<15.200.0"
+erpnext = ">=15.100.0,<15.200.0"
 
 [tool.ruff]
 line-length = 110

--- a/xpos/api/items.py
+++ b/xpos/api/items.py
@@ -4,7 +4,6 @@
 import json
 
 import frappe
-from frappe import _
 from frappe.utils import cint, flt, getdate, nowdate
 
 
@@ -139,8 +138,11 @@ def get_items_count(pos_profile: str, search_term: str = "", item_group: str = "
 		)"""
 		values["search"] = f"%{search_term}%"
 
+	sql = "SELECT COUNT(DISTINCT i.name) FROM `tabItem` i {bin_join} WHERE {conditions}".format(
+		bin_join=bin_join, conditions=conditions
+	)
 	count = frappe.db.sql(
-		f"SELECT COUNT(DISTINCT i.name) FROM `tabItem` i {bin_join} WHERE {conditions}",
+		sql,
 		values,
 	)
 	return count[0][0] if count else 0


### PR DESCRIPTION
This pull request primarily updates project metadata and configuration, with some minor code cleanup and a small SQL query refactor. The most significant changes are to the `pyproject.toml` configuration, including dependency and linting settings, and minor improvements in the `xpos/api/items.py` module.

**Project metadata and configuration updates:**

* Updated the `keywords` in `pyproject.toml` to use "xpos" instead of "pos" and removed the `classifiers` section for a cleaner project metadata definition.
* Broadened the version constraint for the `frappe` dependency in `pyproject.toml` to allow any `>=15.0.0,<16.0.0` version, and removed the `erpnext` dependency constraint.
* Simplified the Ruff linter configuration in `pyproject.toml` by removing the explicit `select`, `ignore`, and per-file ignore settings, and added `typing-modules` for Frappe types.

**Codebase cleanup and minor improvements:**

* Removed an unused import of `_` from `frappe` in `xpos/api/items.py` for code cleanliness.
* Refactored the SQL query construction in `get_items_count` in `xpos/api/items.py` to build the query string separately before execution, improving readability.