### PR TITLE
feat: enhance stock management by adding pos profile handling for stock

### DIFF
--- a/frontend/src/stores/itemStore.ts
+++ b/frontend/src/stores/itemStore.ts
@@ -100,6 +100,7 @@ export const useItemStore = defineStore("items", () => {
 			const stockResult = await call<StockAvailability[]>("xpos.api.items.get_stock_availability", {
 				items: JSON.stringify(itemCodes),
 				warehouse,
+				pos_profile: posProfile,
 			});
 
 			const stockEntries: { item_code: string; actual_qty: number }[] = [];
@@ -426,9 +427,11 @@ export const useItemStore = defineStore("items", () => {
 		warehouse: string,
 	): Promise<StockAvailability[]> {
 		try {
+			const posStoreRef = usePosStore();
 			const result = await call<StockAvailability[]>("xpos.api.items.get_stock_availability", {
 				items: JSON.stringify(itemCodes),
 				warehouse,
+				pos_profile: posStoreRef.profileName || undefined,
 			});
 			return result || [];
 		} catch (error) {

--- a/xpos/api/items.py
+++ b/xpos/api/items.py
@@ -42,6 +42,7 @@ def get_pos_items(
 		]
 
 	hide_unavailable = pos.get("hide_unavailable_items") and warehouse
+	use_pos_deduction = bool(pos.get("create_pos_invoice_instead_of_sales_invoice"))
 
 	if hide_unavailable:
 		wh_list = [warehouse]
@@ -53,6 +54,27 @@ def get_pos_items(
 			filters={"warehouse": ["in", wh_list], "actual_qty": [">", 0]},
 			pluck="item_code",
 		)
+
+		if use_pos_deduction and in_stock_items:
+			pending_map = _get_pending_pos_qty_map(wh_list, item_codes=in_stock_items)
+			if pending_map:
+				from frappe.query_builder import DocType as DT
+				from frappe.query_builder.functions import Sum as SumFn
+
+				BinDT = DT("Bin")
+				bin_rows = (
+					frappe.qb.from_(BinDT)
+					.select(BinDT.item_code, SumFn(BinDT.actual_qty).as_("actual_qty"))
+					.where(BinDT.item_code.isin(in_stock_items))
+					.where(BinDT.warehouse.isin(wh_list))
+					.groupby(BinDT.item_code)
+					.run(as_dict=True)
+				)
+				bin_map = {r.item_code: flt(r.actual_qty) for r in bin_rows}
+				in_stock_items = [
+					ic for ic in in_stock_items if (bin_map.get(ic, 0) - pending_map.get(ic, 0)) > 0
+				]
+
 		non_stock_items = frappe.get_all(
 			"Item",
 			filters={"is_stock_item": 0, "disabled": 0, "is_sales_item": 1},
@@ -102,7 +124,9 @@ def get_pos_items(
 			or 0
 		)
 
-		item.actual_qty = get_stock_qty(item.item_code, warehouse) if warehouse else 0
+		item.actual_qty = (
+			get_stock_qty(item.item_code, warehouse, pos_profile=pos_profile) if warehouse else 0
+		)
 
 	return items
 
@@ -219,7 +243,7 @@ def search_barcode(barcode: str, pos_profile: str | None = None):
 			"has_batch_no": item.has_batch_no,
 			"has_serial_no": item.has_serial_no,
 			"image": item.image,
-			"actual_qty": get_stock_qty(item.name, warehouse) if warehouse else 0,
+			"actual_qty": get_stock_qty(item.name, warehouse, pos_profile=pos_profile) if warehouse else 0,
 		}
 
 	if frappe.db.exists("Item", barcode):
@@ -235,7 +259,7 @@ def search_barcode(barcode: str, pos_profile: str | None = None):
 			"has_batch_no": item.has_batch_no,
 			"has_serial_no": item.has_serial_no,
 			"image": item.image,
-			"actual_qty": get_stock_qty(item.name, warehouse) if warehouse else 0,
+			"actual_qty": get_stock_qty(item.name, warehouse, pos_profile=pos_profile) if warehouse else 0,
 		}
 
 	if pos_profile:
@@ -424,7 +448,7 @@ def get_item_attributes(item_code: str):
 
 
 @frappe.whitelist()
-def get_stock_availability(items: str | list, warehouse: str | None = None):
+def get_stock_availability(items: str | list, warehouse: str | None = None, pos_profile: str | None = None):
 	"""Bulk-fetch stock for multiple items.
 
 	Accepts two calling conventions:
@@ -438,6 +462,20 @@ def get_stock_availability(items: str | list, warehouse: str | None = None):
 		items = json.loads(items)
 	if not items:
 		return []
+
+	use_pos_deduction = bool(pos_profile and _is_pos_invoice_mode(pos_profile))
+	pending_map: dict[str, float] = {}
+	if use_pos_deduction and warehouse:
+		wh_list = [warehouse]
+		if frappe.db.get_value("Warehouse", warehouse, "is_group"):
+			wh_list = frappe.db.get_descendants("Warehouse", warehouse) or []
+		all_item_codes = []
+		for d in items:
+			if isinstance(d, str):
+				all_item_codes.append(d)
+			elif d.get("item_code"):
+				all_item_codes.append(d.get("item_code"))
+		pending_map = _get_pending_pos_qty_map(wh_list, item_codes=all_item_codes)
 
 	results = []
 	for d in items:
@@ -459,6 +497,9 @@ def get_stock_availability(items: str | list, warehouse: str | None = None):
 			qty = flt(get_batch_qty(batch_no, item_warehouse))
 		else:
 			qty = flt(get_stock_qty(item_code, item_warehouse))
+
+		if use_pos_deduction and not batch_no:
+			qty -= pending_map.get(item_code, 0.0)
 
 		results.append({"item_code": item_code, "actual_qty": qty})
 
@@ -502,7 +543,7 @@ def get_price_for_uom(item_code: str, price_list: str, uom: str):
 	return flt(rate) if rate else None
 
 
-def get_stock_qty(item_code: str, warehouse: str):
+def get_stock_qty(item_code: str, warehouse: str, pos_profile: str | None = None):
 	"""Get actual qty from Bin, supporting warehouse groups."""
 	if not warehouse:
 		return 0
@@ -522,7 +563,57 @@ def get_stock_qty(item_code: str, warehouse: str):
 		.where(Bin.warehouse.isin(warehouses))
 		.run(as_dict=True)
 	)
-	return flt(rows[0].actual_qty) if rows else 0
+	bin_qty = flt(rows[0].actual_qty) if rows else 0
+
+	if pos_profile and _is_pos_invoice_mode(pos_profile):
+		pending_map = _get_pending_pos_qty_map(warehouses, item_codes=[item_code])
+		bin_qty -= pending_map.get(item_code, 0.0)
+
+	return bin_qty
+
+
+def _is_pos_invoice_mode(pos_profile: str) -> bool:
+	"""Return True when the POS Profile creates POS Invoices instead of Sales Invoices."""
+	return bool(
+		frappe.db.get_value("POS Profile", pos_profile, "create_pos_invoice_instead_of_sales_invoice")
+	)
+
+
+def _get_pending_pos_qty_map(
+	warehouses: list[str],
+	item_codes: list[str] | None = None,
+) -> dict[str, float]:
+	"""Return qty sold in submitted but unconsolidated POS Invoices.
+
+	Returns a dict mapping item_code -> total pending qty across the
+	given warehouses.  Only submitted (docstatus=1) POS Invoices that
+	have not yet been consolidated are considered.
+	"""
+	from frappe.query_builder import DocType
+	from frappe.query_builder.functions import Sum
+
+	POSInv = DocType("POS Invoice")
+	POSItem = DocType("POS Invoice Item")
+
+	query = (
+		frappe.qb.from_(POSItem)
+		.join(POSInv)
+		.on(POSItem.parent == POSInv.name)
+		.select(
+			POSItem.item_code,
+			Sum(POSItem.stock_qty).as_("total_qty"),
+		)
+		.where(POSInv.docstatus == 1)
+		.where((POSInv.consolidated_invoice == "") | (POSInv.consolidated_invoice.isnull()))
+		.where(POSItem.warehouse.isin(warehouses))
+		.groupby(POSItem.item_code)
+	)
+
+	if item_codes:
+		query = query.where(POSItem.item_code.isin(item_codes))
+
+	rows = query.run(as_dict=True)
+	return {r.item_code: flt(r.total_qty) for r in rows}
 
 
 def _get_batch_data(item_code: str, warehouse: str, today: str | None = None):

--- a/xpos/x_pos/api/invoice_processing/stock.py
+++ b/xpos/x_pos/api/invoice_processing/stock.py
@@ -55,7 +55,7 @@ def _get_available_stock(item):
 	return get_stock_availability(item_code, warehouse)
 
 
-def _collect_stock_errors(items):
+def _collect_stock_errors(items, pos_profile=None):
 	"""Return list of items exceeding available stock."""
 	errors = []
 	items_to_check = []
@@ -76,12 +76,32 @@ def _collect_stock_errors(items):
 
 	stock_map = get_bulk_stock_availability(items_to_check)
 
+	pending_map: dict[tuple[str, str], float] = {}
+	if pos_profile:
+		from xpos.api.items import _get_pending_pos_qty_map, _is_pos_invoice_mode
+
+		if _is_pos_invoice_mode(pos_profile):
+			wh_items: dict[str, list[str]] = {}
+			for d in items_to_check:
+				wh = d.get("warehouse")
+				if wh:
+					wh_items.setdefault(wh, []).append(d.get("item_code"))
+			for wh, codes in wh_items.items():
+				wh_list = [wh]
+				if frappe.db.get_value("Warehouse", wh, "is_group"):
+					wh_list = frappe.db.get_descendants("Warehouse", wh) or []
+				pmap = _get_pending_pos_qty_map(wh_list, item_codes=codes)
+				for ic, qty in pmap.items():
+					pending_map[(ic, wh)] = pending_map.get((ic, wh), 0.0) + qty
+
 	for d in items_to_check:
 		item_code = d.get("item_code")
 		warehouse = d.get("warehouse")
 		batch_no = cstr(d.get("batch_no"))
 
 		available = stock_map.get((item_code, warehouse, batch_no), 0.0)
+		if not batch_no:
+			available -= pending_map.get((item_code, warehouse), 0.0)
 		requested = flt(d.get("stock_qty") or (flt(d.get("qty")) * flt(d.get("conversion_factor") or 1)))
 		if requested > available:
 			errors.append(
@@ -116,8 +136,9 @@ def _validate_stock_on_invoice(invoice_doc):
 	items_to_check = [d.as_dict() for d in invoice_doc.items if d.get("is_stock_item")]
 	if hasattr(invoice_doc, "packed_items"):
 		items_to_check.extend([d.as_dict() for d in invoice_doc.packed_items])
-	errors = _collect_stock_errors(items_to_check)
-	if errors and _should_block(invoice_doc.pos_profile):
+	pos_profile = getattr(invoice_doc, "pos_profile", None)
+	errors = _collect_stock_errors(items_to_check, pos_profile=pos_profile)
+	if errors and _should_block(pos_profile):
 		frappe.throw(frappe.as_json({"errors": errors}), frappe.ValidationError)
 
 
@@ -309,8 +330,6 @@ def _strip_client_freebies_from_payload(payload):
 			continue
 
 		auto_marker = row.get("auto_free_source")
-		is_free = cint(row.get("is_free_item"))
-		has_name = bool(row.get("name"))
 
 		if auto_marker:
 			modified = True


### PR DESCRIPTION
This pull request introduces enhancements to how stock availability is calculated and validated in POS workflows, particularly when POS Invoices are used instead of Sales Invoices. The changes ensure that pending (unconsolidated) POS Invoice quantities are correctly deducted from available stock, both in backend calculations and in API responses. Additionally, the frontend is updated to pass the POS Profile when fetching stock data.

**Backend logic improvements for POS stock deduction:**

* Updated `get_stock_qty`, `get_stock_availability`, and related logic in `xpos/api/items.py` to deduct quantities from submitted but unconsolidated POS Invoices when the POS Profile is set to create POS Invoices instead of Sales Invoices. Helper functions `_is_pos_invoice_mode` and `_get_pending_pos_qty_map` were added for this purpose.
* Modified `get_pos_items` and related stock calculation points to pass the `pos_profile` parameter, ensuring stock is checked in the correct context.

**Frontend updates for POS Profile awareness:**

* Updated the item store in `frontend/src/stores/itemStore.ts` to include the `pos_profile` when fetching stock availability, ensuring the backend receives the relevant context.

**Stock validation improvements in invoice processing:**

* Enhanced stock validation in `xpos/x_pos/api/invoice_processing/stock.py` by passing the `pos_profile` and deducting pending POS Invoice quantities from available stock during validation.

These changes collectively ensure that stock quantities shown and validated in the POS system accurately reflect pending sales, reducing the risk of overselling when using POS Invoices.