### PR TITLE
Validate opening shift before applying shift state

### DIFF
--- a/frontend/src/stores/posStore.ts
+++ b/frontend/src/stores/posStore.ts
@@ -237,7 +237,7 @@ export const usePosStore = defineStore("pos", () => {
 
 			const result = await call<ShiftCheckResult | null>("xpos.api.shifts.check_open_shift");
 
-			if (result) {
+			if (result && result.pos_opening_shift) {
 				applyShiftState(result);
 
 				fetchPrintFormats();


### PR DESCRIPTION
This pull request makes a small but important change to the logic that checks for an open POS shift. Now, the code will only apply the shift state and fetch print formats if the `result` contains a valid `pos_opening_shift` property, adding an extra layer of validation.

- Improved shift validation:
  * Updated the condition in the `usePosStore` store to ensure `applyShiftState` and `fetchPrintFormats` are only called when `result.pos_opening_shift` exists, preventing potential errors when the result is present but does not include a valid shift.