### PR TITLE
fix: enhance filters for fetching POS items and open shifts

### DIFF
--- a/xpos/api/items.py
+++ b/xpos/api/items.py
@@ -19,7 +19,7 @@ def get_pos_items(
 	pos = frappe.get_cached_doc("POS Profile", pos_profile)
 	warehouse = pos.warehouse
 
-	filters = {"disabled": 0, "is_sales_item": 1}
+	filters = {"disabled": 0, "is_sales_item": 1, "is_stock_item": 1}
 
 	if not (include_templates or pos.get("show_template_items")):
 		filters["has_variants"] = 0

--- a/xpos/api/shifts.py
+++ b/xpos/api/shifts.py
@@ -23,6 +23,24 @@ def _row_value(row: dict | object, key: str, default: Any | None = None):
 	return getattr(row, key, default)
 
 
+def _get_open_shift_rows(user: str):
+	return frappe.db.get_all(
+		"POS Opening Shift",
+		filters={
+			"user": user,
+			"docstatus": 1,
+			"status": "Open",
+		},
+		or_filters=[
+			{"pos_closing_shift": ["is", "not set"]},
+			{"pos_closing_shift": ""},
+		],
+		fields=["name", "pos_profile", "company"],
+		order_by="period_start_date desc",
+		limit=1,
+	)
+
+
 @frappe.whitelist()
 def get_opening_data():
 	"""Get data needed for the shift opening dialog.
@@ -108,18 +126,7 @@ def check_open_shift(user: str | None = None):
 
 	user = user or frappe.session.user
 
-	open_shifts = frappe.db.get_all(
-		"POS Opening Shift",
-		filters={
-			"user": user,
-			"pos_closing_shift": ["is", "not set"],
-			"docstatus": 1,
-			"status": "Open",
-		},
-		fields=["name", "pos_profile", "company"],
-		order_by="period_start_date desc",
-		limit=1,
-	)
+	open_shifts = _get_open_shift_rows(user)
 
 	if not open_shifts:
 		return None

--- a/xpos/api/tests/test_shifts.py
+++ b/xpos/api/tests/test_shifts.py
@@ -146,9 +146,18 @@ class TestCheckOpenShift(unittest.TestCase):
 		mock_shift_doc.as_dict.return_value = {"name": "POS-OPEN-003"}
 		mock_frappe.get_doc.return_value = mock_shift_doc
 
+		shifts.check_open_shift(user="manager@test.com")
+
 		mock_frappe.db.get_all.assert_called_once()
 		call_args = mock_frappe.db.get_all.call_args
 		self.assertEqual(call_args.kwargs["filters"]["user"], "manager@test.com")
+		self.assertEqual(
+			call_args.kwargs["or_filters"],
+			[
+				{"pos_closing_shift": ["is", "not set"]},
+				{"pos_closing_shift": ""},
+			],
+		)
 
 
 class TestCloseShift(unittest.TestCase):

--- a/xpos/x_pos/api/shifts.py
+++ b/xpos/x_pos/api/shifts.py
@@ -82,14 +82,19 @@ def create_opening_voucher(pos_profile: str, company: str, balance_details: str)
 
 @frappe.whitelist()
 def check_opening_shift(user: str | None = None):
+	user = user or frappe.session.user
+
 	open_vouchers = frappe.db.get_all(
 		"POS Opening Shift",
 		filters={
 			"user": user,
-			"pos_closing_shift": ["is", "not set"],
 			"docstatus": 1,
 			"status": "Open",
 		},
+		or_filters=[
+			{"pos_closing_shift": ["is", "not set"]},
+			{"pos_closing_shift": ""},
+		],
 		fields=["name", "pos_profile"],
 		order_by="period_start_date desc",
 	)


### PR DESCRIPTION
This pull request improves the handling of open POS shifts and item filtering in the POS system. The main changes focus on making the logic for detecting open shifts more robust and reusable, as well as refining the item filter criteria.

**Open Shift Handling Improvements:**

* Refactored the logic for fetching open POS shifts into a new helper function `_get_open_shift_rows` in `xpos/api/shifts.py`, ensuring consistent behavior and easier maintenance.
* Updated the `check_open_shift` function to use `_get_open_shift_rows`, simplifying the code and ensuring that open shifts are detected even if the `pos_closing_shift` field is either unset or empty.
* Updated the test `test_check_open_shift_uses_provided_user` to verify that both possible `or_filters` for open shifts are included in the query.
* Applied the same open shift detection logic to `check_opening_shift` in `xpos/x_pos/api/shifts.py` by adding the `or_filters` for `pos_closing_shift`.

**Item Filtering Update:**

* Modified the item filter in `get_pos_items` (in `xpos/api/items.py`) to require `is_stock_item` to be true, ensuring only stock items are included in POS item queries.