### PR TITLE
Refactor bank drop view and improve detail dialog

### DIFF
--- a/frontend/src/components/dialogs/BankDropDetailDialog.vue
+++ b/frontend/src/components/dialogs/BankDropDetailDialog.vue
@@ -1,0 +1,174 @@
+<template>
+	<Dialog
+		:open="!!bankDrop"
+		@update:open="
+			(value: boolean) => {
+				if (!value) emit('close');
+			}
+		"
+	>
+		<DialogContent class="sm:max-w-lg">
+			<DialogHeader>
+				<div class="flex items-start gap-3">
+					<div
+						class="w-9 h-9 rounded-lg flex items-center justify-center bg-emerald-500/10 text-emerald-500 shrink-0"
+					>
+						<ArrowUpCircle class="w-4 h-4" />
+					</div>
+					<div class="min-w-0 flex-1">
+						<DialogTitle class="text-base flex items-center gap-2 flex-wrap">
+							<span class="min-w-0 truncate">{{ bankDropTitle }}</span>
+							<Badge
+								v-if="bankDrop"
+								:variant="statusVariant(bankDrop.docstatus)"
+								class="text-[10px]"
+							>
+								{{ __(statusLabel(bankDrop.docstatus)) }}
+							</Badge>
+						</DialogTitle>
+						<DialogDescription>{{ bankDrop?.name }}</DialogDescription>
+					</div>
+				</div>
+			</DialogHeader>
+
+			<div v-if="bankDrop" class="space-y-5">
+				<div class="rounded-lg border border-border p-4 bg-muted/20">
+					<div class="text-xs text-muted-foreground uppercase tracking-wide mb-1">
+						{{ __("Amount") }}
+					</div>
+					<div class="text-2xl font-bold text-emerald-500">
+						{{ posStore.currencySymbol }}{{ formatAmount(bankDrop.amount) }}
+					</div>
+				</div>
+
+				<div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
+					<div class="space-y-1">
+						<span class="text-xs text-muted-foreground uppercase tracking-wide">
+							{{ __("Posting Date") }}
+						</span>
+						<p class="font-medium text-foreground">{{ formatDate(bankDrop.posting_date) }}</p>
+					</div>
+					<div class="space-y-1">
+						<span class="text-xs text-muted-foreground uppercase tracking-wide">
+							{{ __("Deposit To") }}
+						</span>
+						<p class="font-medium text-foreground break-words">
+							{{ bankDrop.target_account || bankDrop.to_account || "-" }}
+						</p>
+					</div>
+					<div class="space-y-1">
+						<span class="text-xs text-muted-foreground uppercase tracking-wide">
+							{{ __("Reference") }}
+						</span>
+						<p class="font-medium text-foreground break-all">{{ bankDrop.name }}</p>
+					</div>
+					<div v-if="bankDrop.company" class="space-y-1">
+						<span class="text-xs text-muted-foreground uppercase tracking-wide">
+							{{ __("Company") }}
+						</span>
+						<p class="font-medium text-foreground break-words">{{ bankDrop.company }}</p>
+					</div>
+					<div v-if="bankDrop.pos_profile" class="space-y-1">
+						<span class="text-xs text-muted-foreground uppercase tracking-wide">
+							{{ __("POS Profile") }}
+						</span>
+						<p class="font-medium text-foreground break-words">{{ bankDrop.pos_profile }}</p>
+					</div>
+					<div v-if="bankDrop.user" class="space-y-1">
+						<span class="text-xs text-muted-foreground uppercase tracking-wide">
+							{{ __("User") }}
+						</span>
+						<p class="font-medium text-foreground break-words">{{ bankDrop.user }}</p>
+					</div>
+				</div>
+
+				<div v-if="bankDrop.remarks" class="space-y-1">
+					<span class="text-xs text-muted-foreground uppercase tracking-wide">
+						{{ __("Reason / Notes") }}
+					</span>
+					<p class="text-sm text-foreground whitespace-pre-wrap break-words">
+						{{ bankDrop.remarks }}
+					</p>
+				</div>
+			</div>
+		</DialogContent>
+	</Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { usePosStore } from "@/stores/posStore";
+import { Badge } from "@/components/ui/badge";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ArrowUpCircle } from "lucide-vue-next";
+import __ from "@/lib/translate";
+
+interface BankDropDetail {
+	name: string;
+	target_account?: string;
+	to_account?: string;
+	amount: number;
+	remarks?: string;
+	posting_date?: string;
+	docstatus: number;
+	company?: string;
+	pos_profile?: string;
+	user?: string;
+}
+
+const props = defineProps<{
+	bankDrop: BankDropDetail | null;
+}>();
+
+const emit = defineEmits<{
+	(e: "close"): void;
+}>();
+
+const posStore = usePosStore();
+
+const bankDropTitle = computed(() => {
+	if (!props.bankDrop) {
+		return "";
+	}
+	return (
+		props.bankDrop.remarks?.trim() ||
+		props.bankDrop.target_account ||
+		props.bankDrop.to_account ||
+		__("Cash Deposit")
+	);
+});
+
+function statusLabel(docstatus: number) {
+	return (
+		{
+			0: "Draft",
+			1: "Submitted",
+			2: "Cancelled",
+		}[Number(docstatus) || 0] || "Unknown"
+	);
+}
+
+function statusVariant(
+	docstatus: number,
+): "default" | "success" | "warning" | "destructive" | "secondary" | "outline" {
+	const variants: Record<number, "success" | "secondary" | "outline"> = {
+		0: "outline",
+		1: "success",
+		2: "secondary",
+	};
+	return variants[Number(docstatus) || 0] || "secondary";
+}
+
+function formatDate(date?: string) {
+	if (!date) return "-";
+	return new Date(date).toLocaleDateString(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function formatAmount(amount: number | string) {
+	return parseFloat(String(amount) || "0").toFixed(2);
+}
+</script>

--- a/frontend/src/views/BankDropView.vue
+++ b/frontend/src/views/BankDropView.vue
@@ -1,115 +1,210 @@
 <template>
-	<div class="flex flex-col h-full overflow-hidden bg-background">
-		<div class="shrink-0 p-4 pb-3">
-			<div class="flex items-center justify-between mb-4">
-				<h1 class="text-xl font-bold text-foreground">{{ __("Bank Drops") }}</h1>
+	<div class="h-full min-h-0">
+		<BaseListView
+			v-if="isElectronMode"
+			:title="__('Bank Drops')"
+			:fields="allFilterableFields"
+			:standard-filter-fields="standardFilterFields"
+			:standard-filters="standardFilterModel"
+			:query-filters="queryFilterModel"
+			:order-by="sortOrder"
+			:is-loading="isLoading"
+			:items="paginatedDrops"
+			:total="filteredDrops.length"
+			:page-size="pageSize"
+			:current-page="currentPage"
+			empty-title="No bank drops found"
+			:empty-description="emptyDescription"
+			:empty-icon="Landmark"
+			item-key="name"
+			@update:standard-filters="onStandardFilterUpdate"
+			@update:query-filters="onQueryFilterUpdate"
+			@update:order-by="setSortOrder"
+			@refresh="loadDrops"
+			@clear-filters="clearAllFilters"
+			@update:current-page="handlePageChange"
+			@update:page-size="handlePageSizeChange"
+		>
+			<template #header-actions>
 				<Button size="sm" @click="openForm" :disabled="!canAddBankDrop">
 					<Plus class="w-4 h-4 me-1" />
 					{{ __("New Bank Drop") }}
 				</Button>
-			</div>
+			</template>
 
-			<div class="flex items-center gap-3">
-				<DateTimePicker
-					v-model="fromDate"
-					mode="date"
-					placeholder="From Date"
-					:show-today="true"
-					:clearable="true"
-					class="w-52"
-				/>
-				<span class="text-muted-foreground text-sm">to</span>
-				<DateTimePicker
-					v-model="toDate"
-					mode="date"
-					placeholder="To Date"
-					:show-today="true"
-					:clearable="true"
-					class="w-52"
-				/>
-				<Button variant="outline" size="sm" @click="loadDrops">
-					<RefreshCw class="w-4 h-4" />
-				</Button>
-			</div>
-		</div>
-
-		<div class="flex-1 overflow-y-auto px-4 xpos-scrollbar">
-			<div v-if="isLoading" class="grid gap-3">
-				<div v-for="i in 4" :key="i" class="skeleton h-16 w-full rounded-xl"></div>
-			</div>
-			<div
-				v-else-if="drops.length === 0"
-				class="flex flex-col items-center justify-center h-64 text-muted-foreground"
-			>
-				<Landmark class="w-16 h-16 mb-4 text-muted-foreground/30" />
-				<p class="text-lg font-medium">{{ __("No bank drops found") }}</p>
-				<p class="text-sm">{{ __("Record a cash drop to the bank") }}</p>
-			</div>
-
-			<div v-else class="space-y-2">
-				<Card v-for="drop in drops" :key="drop.id" class="p-4">
-					<div class="flex items-center gap-4">
+			<template #item="{ item: drop }">
+				<Card
+					class="p-3 sm:p-4 cursor-pointer transition-all duration-200 border-border/60 dark:border-transparent hover:border-primary/40 hover:shadow-md dark:hover:bg-accent/50 dark:hover:shadow-primary/5"
+					@click="openBankDropDetail(drop)"
+				>
+					<div class="flex items-center gap-2 sm:gap-4">
 						<div
-							class="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 bg-emerald-500/10 text-emerald-500"
+							class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 bg-emerald-500/10 text-emerald-500"
 						>
 							<ArrowUpCircle class="w-4 h-4" />
 						</div>
 						<div class="min-w-0 flex-1">
-							<div class="flex items-center gap-2 mb-1">
-								<span
-									class="font-semibold text-foreground"
-									:title="drop.remarks || drop.target_account || drop.to_account"
-								>
-									{{ drop.remarks || drop.target_account || drop.to_account }}
+							<div class="flex items-center gap-2 mb-1 flex-wrap">
+								<span class="font-semibold text-foreground text-sm leading-tight">
+									{{ bankDropTitle(drop) }}
 								</span>
-								<Badge
-									:variant="drop.docstatus === 1 ? 'default' : 'secondary'"
-									class="text-[10px]"
-								>
-									{{ DOCSTATUS_MAP[drop.docstatus ?? 0] }}
+								<Badge :variant="statusVariant(drop.docstatus)" class="text-[10px]">
+									{{ __(statusLabel(drop.docstatus)) }}
 								</Badge>
 							</div>
-							<div class="flex items-center gap-3 text-xs text-muted-foreground">
-								<span>{{ drop.posting_date }}</span>
+							<div
+								class="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground"
+							>
 								<span
-									v-if="
-										!posStore.requireCashMovementRemarks &&
-										!!drop.remarks &&
-										(drop.target_account || drop.to_account)
-									"
-									class="truncate max-w-[400px]"
+									class="flex items-center gap-1 min-w-0 truncate max-w-[120px] sm:max-w-none"
+								>
+									{{ drop.name }}
+								</span>
+								<span
+									v-if="drop.posting_date"
+									class="flex items-center gap-1 whitespace-nowrap"
+								>
+									<CalendarIcon class="h-3 w-3 shrink-0" />
+									{{ formatDate(drop.posting_date) }}
+								</span>
+								<span
+									v-if="drop.target_account"
+									class="min-w-0 truncate max-w-[160px] sm:max-w-none"
+								>
+									{{ drop.target_account }}
+								</span>
+								<span
+									v-if="drop.remarks"
+									class="hidden sm:inline min-w-0 truncate max-w-[280px]"
 								>
 									{{ drop.remarks }}
 								</span>
 							</div>
 						</div>
-						<div class="text-end">
-							<span class="font-bold text-emerald-500">
+
+						<div class="text-end shrink-0">
+							<div class="font-bold text-base sm:text-lg leading-tight text-emerald-500">
 								{{ posStore.currencySymbol }}{{ formatPrice(drop.amount) }}
-							</span>
+							</div>
+							<div class="text-xs text-muted-foreground whitespace-nowrap">
+								{{ __("Deposit") }}
+							</div>
 						</div>
+
 						<Button
-							v-if="drop.docstatus === 0 || drop.can_delete"
+							v-if="canDelete(drop)"
 							variant="ghost"
 							size="icon"
-							class="text-destructive h-8 w-8"
-							@click="handleDelete(drop.id)"
+							class="text-destructive h-8 w-8 shrink-0"
+							@click.stop="handleDelete(drop.id)"
 						>
 							<Trash2 class="w-4 h-4" />
 						</Button>
+
+						<ChevronRight class="w-4 h-4 sm:w-5 sm:h-5 text-muted-foreground/40 shrink-0" />
 					</div>
 				</Card>
-			</div>
-		</div>
+			</template>
+		</BaseListView>
 
-		<Pagination
-			v-if="totalDrops > 0"
-			:total="totalDrops"
-			:page-size="pageSize"
-			:current-page="currentPage"
-			@update:current-page="handlePageChange"
-			@update:page-size="handlePageSizeChange"
-		/>
+		<ListView
+			v-else
+			:key="browserListKey"
+			:title="__('Bank Drops')"
+			doctype="POS Cash Movement"
+			:fields="browserFields"
+			:base-filters="browserBaseFilters"
+			default-order-by="posting_date desc, creation desc"
+			:default-page-size="20"
+			empty-title="No bank drops found"
+			:empty-description="emptyDescription"
+			:empty-icon="Landmark"
+			item-key="name"
+		>
+			<template #header-actions>
+				<Button size="sm" @click="openForm" :disabled="!canAddBankDrop">
+					<Plus class="w-4 h-4 me-1" />
+					{{ __("New Bank Drop") }}
+				</Button>
+			</template>
+
+			<template #item="{ item: drop }">
+				<Card
+					class="p-3 sm:p-4 cursor-pointer transition-all duration-200 border-border/60 dark:border-transparent hover:border-primary/40 hover:shadow-md dark:hover:bg-accent/50 dark:hover:shadow-primary/5"
+					@click="openBankDropDetail(drop)"
+				>
+					<div class="flex items-center gap-2 sm:gap-4">
+						<div
+							class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 bg-emerald-500/10 text-emerald-500"
+						>
+							<ArrowUpCircle class="w-4 h-4" />
+						</div>
+						<div class="min-w-0 flex-1">
+							<div class="flex items-center gap-2 mb-1 flex-wrap">
+								<span class="font-semibold text-foreground text-sm leading-tight">
+									{{ bankDropTitle(drop) }}
+								</span>
+								<Badge
+									:variant="statusVariant(Number(drop.docstatus || 0))"
+									class="text-[10px]"
+								>
+									{{ __(statusLabel(Number(drop.docstatus || 0))) }}
+								</Badge>
+							</div>
+							<div
+								class="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground"
+							>
+								<span
+									class="flex items-center gap-1 min-w-0 truncate max-w-[120px] sm:max-w-none"
+								>
+									{{ drop.name }}
+								</span>
+								<span
+									v-if="drop.posting_date"
+									class="flex items-center gap-1 whitespace-nowrap"
+								>
+									<CalendarIcon class="h-3 w-3 shrink-0" />
+									{{ formatDate(String(drop.posting_date)) }}
+								</span>
+								<span
+									v-if="drop.target_account"
+									class="min-w-0 truncate max-w-[160px] sm:max-w-none"
+								>
+									{{ drop.target_account }}
+								</span>
+								<span
+									v-if="drop.remarks"
+									class="hidden sm:inline min-w-0 truncate max-w-[280px]"
+								>
+									{{ drop.remarks }}
+								</span>
+							</div>
+						</div>
+
+						<div class="text-end shrink-0">
+							<div class="font-bold text-base sm:text-lg leading-tight text-emerald-500">
+								{{ posStore.currencySymbol }}{{ formatPrice(drop.amount) }}
+							</div>
+							<div class="text-xs text-muted-foreground whitespace-nowrap">
+								{{ __("Deposit") }}
+							</div>
+						</div>
+
+						<Button
+							v-if="canDelete(normalizeBankDrop(drop))"
+							variant="ghost"
+							size="icon"
+							class="text-destructive h-8 w-8 shrink-0"
+							@click.stop="handleDelete(String(drop.name || drop.id || ''))"
+						>
+							<Trash2 class="w-4 h-4" />
+						</Button>
+
+						<ChevronRight class="w-4 h-4 sm:w-5 sm:h-5 text-muted-foreground/40 shrink-0" />
+					</div>
+				</Card>
+			</template>
+		</ListView>
 
 		<Dialog :open="showForm" @update:open="showForm = $event">
 			<DialogContent class="sm:max-w-md">
@@ -176,21 +271,26 @@
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>
+
+		<BankDropDetailDialog :bank-drop="selectedBankDrop" @close="selectedBankDrop = null" />
 	</div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { usePosStore } from "@/stores/posStore";
 import { useAuthStore } from "@/stores/authStore";
 import { usePaymentStore } from "@/stores/paymentStore";
 import { hasPermission } from "@/services/userRights";
 import { createBankDrop, getBankDrops, deleteBankDrop } from "@/services/dbBridge";
 import { isElectron } from "@/services/electronBridge";
-import { showSuccess, showError } from "@/services/api";
+import { call, showSuccess, showError } from "@/services/api";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import BaseListView from "@/components/core/BaseListView.vue";
+import ListView from "@/components/core/ListView.vue";
+import BankDropDetailDialog from "@/components/dialogs/BankDropDetailDialog.vue";
 import { NumberInput } from "@/components/ui/number-input";
 import {
 	Dialog,
@@ -200,11 +300,18 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import { Plus, RefreshCw, Trash2, Landmark, Loader2, ArrowUpCircle } from "lucide-vue-next";
-import DateTimePicker from "@/components/ui/datetime-picker/DateTimePicker.vue";
-import Pagination from "@/components/orders/Pagination.vue";
+import {
+	Plus,
+	Trash2,
+	Landmark,
+	Loader2,
+	ArrowUpCircle,
+	Calendar as CalendarIcon,
+	ChevronRight,
+} from "lucide-vue-next";
 import __ from "@/lib/translate";
-import { DOCSTATUS_MAP } from "@/types/pos.types";
+import type { DocField } from "@/services/doctypeMeta";
+import type { QueryFilter } from "@/composables/useListView";
 import { Select } from "@/components/ui/select";
 
 const posStore = usePosStore();
@@ -213,29 +320,56 @@ const paymentStore = usePaymentStore();
 
 interface BankDrop {
 	id: number | string;
+	name: string;
 	target_account?: string;
 	to_account?: string;
 	amount: number;
 	remarks?: string;
 	posting_date?: string;
-	docstatus?: number;
+	docstatus: number;
 	can_delete?: boolean;
+	company?: string;
+	pos_profile?: string;
+	user?: string;
+	movement_type?: string;
+	creation?: string;
 }
 
 const isLoading = ref(false);
 const isSaving = ref(false);
 const showForm = ref(false);
-const drops = ref<BankDrop[]>([]);
+const selectedBankDrop = ref<BankDrop | null>(null);
+const browserListKey = ref(0);
+const rawDrops = ref<BankDrop[]>([]);
 const isElectronMode = isElectron();
 
-const today = new Date().toISOString().slice(0, 10);
-const fromDate = ref(today);
-const toDate = ref(today);
+const browserFields = [
+	"name",
+	"posting_date",
+	"target_account",
+	"remarks",
+	"amount",
+	"docstatus",
+	"company",
+	"pos_profile",
+	"user",
+	"creation",
+];
+
+const browserBaseFilters = computed(() => ({
+	movement_type: "Deposit",
+	pos_opening_shift: posStore.posOpeningShift?.name || "__missing_shift__",
+}));
+
+const emptyDescription = computed(() =>
+	posStore.posOpeningShift?.name ? __("Try adjusting your filters") : __("Open a shift to view bank drops"),
+);
 
 const currentPage = ref(1);
 const pageSize = ref(20);
-const totalDrops = ref(0);
-const allElectronDrops = ref<BankDrop[]>([]);
+const sortOrder = ref("posting_date desc");
+const standardFilters = ref<Record<string, unknown>>({});
+const queryFilters = ref<QueryFilter[]>([]);
 
 const canAddBankDrop = computed(() => hasPermission("bank_drop") && posStore.allowCashDeposit);
 
@@ -245,30 +379,306 @@ const form = ref({
 	reason: "",
 });
 
+const allFilterableFields = computed<DocField[]>(() => [
+	{ fieldname: "name", fieldtype: "Data", label: __("ID"), in_standard_filter: 1 },
+	{ fieldname: "posting_date", fieldtype: "Date", label: __("Posting Date"), in_standard_filter: 1 },
+	{
+		fieldname: "target_account",
+		fieldtype: "Data",
+		label: __("Deposit To"),
+		in_standard_filter: 1,
+	},
+	{ fieldname: "remarks", fieldtype: "Data", label: __("Remarks"), in_standard_filter: 1 },
+	{
+		fieldname: "status",
+		fieldtype: "Select",
+		label: __("Status"),
+		options: "Draft\nSubmitted\nCancelled",
+		in_standard_filter: 1,
+	},
+	{ fieldname: "amount", fieldtype: "Currency", label: __("Amount") },
+]);
+
+const standardFilterFields = computed(() =>
+	allFilterableFields.value.filter((field) => field.in_standard_filter === 1),
+);
+
 const depositAccountOptions = computed(() => {
 	const ctx = paymentStore.cashMovementContext;
 	if (ctx?.deposit_accounts) {
-		return ctx.deposit_accounts.map((ac) => ({
-			label: ac.name,
-			value: ac.name,
+		return ctx.deposit_accounts.map((account) => ({
+			label: account.name,
+			value: account.name,
 		}));
 	}
 	return [];
 });
 
-const canSubmit = computed(() => {
-	return form.value.amount > 0 && !!form.value.target_account;
+const standardFilterModel = computed(() => ({ ...standardFilters.value }));
+
+const queryFilterModel = computed(() =>
+	queryFilters.value.map((filter) => ({
+		field: filter.field,
+		operator: filter.operator,
+		value: filter.value,
+	})),
+);
+
+const filteredDrops = computed(() => {
+	const rows = [...rawDrops.value].filter((drop) => {
+		for (const [field, value] of Object.entries(standardFilters.value)) {
+			if (!matchesStandardFilter(drop, field, value)) {
+				return false;
+			}
+		}
+
+		for (const filter of queryFilters.value) {
+			if (!matchesQueryFilter(drop, filter)) {
+				return false;
+			}
+		}
+
+		return true;
+	});
+
+	const { field, direction } = parseSortOrder(sortOrder.value);
+	rows.sort((left, right) => compareBankDrops(left, right, field, direction));
+
+	return rows;
 });
+
+const paginatedDrops = computed(() => {
+	const start = (currentPage.value - 1) * pageSize.value;
+	return filteredDrops.value.slice(start, start + pageSize.value);
+});
+
+const canSubmit = computed(() => form.value.amount > 0 && form.value.target_account.trim() !== "");
+
+watch(
+	() => filteredDrops.value.length,
+	(length) => {
+		const maxPage = Math.max(1, Math.ceil(length / pageSize.value));
+		if (currentPage.value > maxPage) {
+			currentPage.value = maxPage;
+		}
+	},
+);
 
 function formatPrice(price: number | string) {
 	return parseFloat(String(price) || "0").toFixed(2);
+}
+
+function formatDate(date: string) {
+	if (!date) return "";
+	return new Date(date).toLocaleDateString(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function statusLabel(docstatus: number) {
+	return (
+		{
+			0: "Draft",
+			1: "Submitted",
+			2: "Cancelled",
+		}[Number(docstatus) || 0] || "Unknown"
+	);
+}
+
+function statusVariant(
+	docstatus: number,
+): "default" | "success" | "warning" | "destructive" | "secondary" | "outline" {
+	const variants: Record<number, "success" | "secondary" | "outline"> = {
+		0: "outline",
+		1: "success",
+		2: "secondary",
+	};
+	return variants[Number(docstatus) || 0] || "secondary";
+}
+
+function bankDropTitle(drop: BankDrop | Record<string, unknown>) {
+	const bankDrop = normalizeBankDrop(drop);
+	return bankDrop.remarks?.trim() || bankDrop.target_account || bankDrop.to_account || __("Cash Deposit");
+}
+
+function canDelete(drop: BankDrop) {
+	return drop.docstatus === 0 || !!drop.can_delete;
+}
+
+function getFieldDefinition(fieldname: string) {
+	return allFilterableFields.value.find((field) => field.fieldname === fieldname);
+}
+
+function getFieldValue(drop: BankDrop, fieldname: string): unknown {
+	if (fieldname === "status") {
+		return statusLabel(drop.docstatus);
+	}
+	if (fieldname === "name") {
+		return drop.name;
+	}
+	return (drop as unknown as Record<string, unknown>)[fieldname];
+}
+
+function normalizeText(value: unknown) {
+	return String(value ?? "")
+		.trim()
+		.toLowerCase();
+}
+
+function normalizeNumber(value: unknown) {
+	const number = Number(value);
+	return Number.isFinite(number) ? number : 0;
+}
+
+function normalizeDate(value: unknown) {
+	return String(value ?? "").trim();
+}
+
+function matchesStandardFilter(drop: BankDrop, fieldname: string, filterValue: unknown) {
+	if (filterValue === undefined || filterValue === null || filterValue === "") {
+		return true;
+	}
+
+	const field = getFieldDefinition(fieldname);
+	const value = getFieldValue(drop, fieldname);
+
+	if (field?.fieldtype === "Select") {
+		return normalizeText(value) === normalizeText(filterValue);
+	}
+
+	if (field?.fieldtype === "Currency") {
+		return normalizeNumber(value) === normalizeNumber(filterValue);
+	}
+
+	if (field?.fieldtype === "Date") {
+		return normalizeDate(value) === normalizeDate(filterValue);
+	}
+
+	return normalizeText(value).includes(normalizeText(filterValue));
+}
+
+function matchesQueryFilter(drop: BankDrop, filter: QueryFilter) {
+	const field = getFieldDefinition(filter.field);
+	const value = getFieldValue(drop, filter.field);
+	const operator = filter.operator;
+	const filterValue = filter.value;
+
+	if (operator === "is" || operator === "is not") {
+		const isSet = normalizeText(value) !== "";
+		const wantsSet = normalizeText(filterValue) === "set";
+		return operator === "is" ? isSet === wantsSet : isSet !== wantsSet;
+	}
+
+	if (field?.fieldtype === "Currency") {
+		const left = normalizeNumber(value);
+		const right = normalizeNumber(filterValue);
+		return compareByOperator(left, right, operator);
+	}
+
+	if (field?.fieldtype === "Date") {
+		const left = normalizeDate(value);
+		if (operator === "between") {
+			const [from, to] = filterValue.split(",").map((part) => part.trim());
+			if (!from || !to) return true;
+			return left >= from && left <= to;
+		}
+		return compareByOperator(left, normalizeDate(filterValue), operator);
+	}
+
+	const left = normalizeText(value);
+	const right = normalizeText(filterValue);
+
+	if (operator === "like") {
+		return left.includes(right);
+	}
+	if (operator === "not like") {
+		return !left.includes(right);
+	}
+
+	return compareByOperator(left, right, operator);
+}
+
+function compareByOperator<T>(left: T, right: T, operator: string) {
+	switch (operator) {
+		case "=":
+			return left === right;
+		case "!=":
+			return left !== right;
+		case ">":
+			return left > right;
+		case "<":
+			return left < right;
+		case ">=":
+			return left >= right;
+		case "<=":
+			return left <= right;
+		default:
+			return true;
+	}
+}
+
+function parseSortOrder(order: string) {
+	const [field = "posting_date", direction = "desc"] = order.trim().split(/\s+/);
+	return {
+		field,
+		direction: direction.toLowerCase() === "asc" ? "asc" : "desc",
+	} as const;
+}
+
+function compareBankDrops(left: BankDrop, right: BankDrop, fieldname: string, direction: "asc" | "desc") {
+	const field = getFieldDefinition(fieldname);
+	const multiplier = direction === "asc" ? 1 : -1;
+
+	if (fieldname === "status") {
+		return (left.docstatus - right.docstatus) * multiplier;
+	}
+
+	const leftValue = getFieldValue(left, fieldname);
+	const rightValue = getFieldValue(right, fieldname);
+
+	if (field?.fieldtype === "Currency") {
+		return (normalizeNumber(leftValue) - normalizeNumber(rightValue)) * multiplier;
+	}
+
+	if (field?.fieldtype === "Date") {
+		return normalizeDate(leftValue).localeCompare(normalizeDate(rightValue)) * multiplier;
+	}
+
+	return normalizeText(leftValue).localeCompare(normalizeText(rightValue)) * multiplier;
+}
+
+function onStandardFilterUpdate(updated: Record<string, unknown>) {
+	standardFilters.value = updated;
+	currentPage.value = 1;
+}
+
+function onQueryFilterUpdate(filters: { field: string; operator: string; value: string }[]) {
+	queryFilters.value = filters.map((filter) => ({
+		field: filter.field,
+		operator: filter.operator as QueryFilter["operator"],
+		value: filter.value,
+	}));
+	currentPage.value = 1;
+}
+
+function clearAllFilters() {
+	standardFilters.value = {};
+	queryFilters.value = [];
+	currentPage.value = 1;
+}
+
+function setSortOrder(value: string) {
+	sortOrder.value = value;
+	currentPage.value = 1;
 }
 
 function openForm() {
 	form.value = { target_account: "", amount: 0, reason: "" };
 	if (posStore.backOfficeCashAccount) {
 		const hasDefault = depositAccountOptions.value.some(
-			(ac) => ac.value === posStore.backOfficeCashAccount,
+			(account) => account.value === posStore.backOfficeCashAccount,
 		);
 		if (hasDefault) {
 			form.value.target_account = posStore.backOfficeCashAccount;
@@ -277,63 +687,52 @@ function openForm() {
 	showForm.value = true;
 }
 
-watch([fromDate, toDate], () => {
-	currentPage.value = 1;
-	loadDrops();
-});
+function openBankDropDetail(drop: BankDrop | Record<string, unknown>) {
+	selectedBankDrop.value = normalizeBankDrop(drop);
+}
+
+function refreshBrowserList() {
+	browserListKey.value += 1;
+}
 
 function handlePageChange(page: number) {
 	currentPage.value = page;
-	loadDrops();
 }
 
 function handlePageSizeChange(size: number) {
 	pageSize.value = size;
 	currentPage.value = 1;
-	loadDrops();
+}
+
+function normalizeBankDrop(row: Record<string, unknown> | BankDrop): BankDrop {
+	const record = row as Record<string, unknown>;
+	const name = String(record.name || record.id || "");
+	return {
+		id: String(record.id || name),
+		name,
+		target_account: String(record.target_account || record.to_account || "") || undefined,
+		to_account: String(record.to_account || record.target_account || "") || undefined,
+		amount: Number(record.amount || 0),
+		remarks: String(record.remarks || "") || undefined,
+		posting_date: String(record.posting_date || "") || undefined,
+		docstatus: Number(record.docstatus || 0),
+		can_delete: Boolean(record.can_delete ?? Number(record.docstatus || 0) < 2),
+		company: String(record.company || "") || undefined,
+		pos_profile: String(record.pos_profile || "") || undefined,
+		user: String(record.user || "") || undefined,
+		movement_type: String(record.movement_type || "Deposit") || undefined,
+		creation: String(record.creation || "") || undefined,
+	};
 }
 
 async function loadDrops() {
 	isLoading.value = true;
 	try {
-		if (isElectronMode) {
-			allElectronDrops.value = (await getBankDrops({
-				user: authStore.userEmail,
-				fromDate: fromDate.value,
-				toDate: toDate.value,
-			})) as BankDrop[];
-			totalDrops.value = allElectronDrops.value.length;
-			const start = (currentPage.value - 1) * pageSize.value;
-			drops.value = allElectronDrops.value.slice(start, start + pageSize.value);
-		} else {
-			const shift = posStore.posOpeningShift?.name;
-			if (shift) {
-				const limit_start = (currentPage.value - 1) * pageSize.value;
-				const { data, total } = await paymentStore.fetchShiftCashMovements(
-					shift,
-					"Deposit",
-					fromDate.value,
-					toDate.value,
-					limit_start,
-					pageSize.value,
-				);
-				totalDrops.value = total;
-				drops.value = data.map((m) => {
-					const r = m as Record<string, unknown>;
-					return {
-						id: String(r.name || ""),
-						target_account: String(r.target_account || r.account || ""),
-						amount: Number(r.amount || 0),
-						remarks: String(r.remarks || ""),
-						posting_date: String(r.posting_date || ""),
-						docstatus: r.docstatus as number,
-						can_delete: r.docstatus === 0 || r.docstatus === 1,
-					};
-				});
-			}
-		}
-	} catch (err) {
-		console.error("Failed to load bank drops:", err);
+		const rows = await getBankDrops({ user: authStore.userEmail });
+		rawDrops.value = (rows as BankDrop[]).map((drop) => normalizeBankDrop(drop));
+	} catch (error) {
+		console.error("Failed to load bank drops", error);
+		showError(__("Failed to load bank drops"));
 	} finally {
 		isLoading.value = false;
 	}
@@ -343,12 +742,13 @@ async function handleSave() {
 	if (!canSubmit.value) return;
 	isSaving.value = true;
 	try {
+		const postingDate = new Date().toISOString().slice(0, 10);
 		if (isElectronMode) {
 			await createBankDrop({
 				to_account: form.value.target_account,
 				amount: form.value.amount,
 				remarks: form.value.reason,
-				posting_date: today,
+				posting_date: postingDate,
 				company: posStore.companyName,
 				user: authStore.userEmail,
 				pos_opening_entry_id: posStore.posOpeningShift?.name
@@ -365,13 +765,17 @@ async function handleSave() {
 				pos_opening_shift: posStore.posOpeningShift?.name || "",
 			});
 		}
+
 		showSuccess(__("Cash deposit recorded"));
 		showForm.value = false;
-		form.value = { target_account: "", amount: 0, reason: "" };
-		await loadDrops();
-	} catch (err) {
+		if (isElectronMode) {
+			await loadDrops();
+		} else {
+			refreshBrowserList();
+		}
+	} catch (error) {
 		showError(__("Failed to record deposit"));
-		console.error("Failed to save bank drop:", err);
+		console.error("Failed to save bank drop", error);
 	} finally {
 		isSaving.value = false;
 	}
@@ -382,26 +786,36 @@ async function handleDelete(id: number | string) {
 		if (isElectronMode) {
 			await deleteBankDrop(id);
 		} else {
-			const { call } = await import("@/services/api");
 			await call("frappe.client.cancel", { doctype: "POS Cash Movement", name: String(id) });
 		}
+
+		if (selectedBankDrop.value && String(selectedBankDrop.value.id) === String(id)) {
+			selectedBankDrop.value = null;
+		}
+
 		showSuccess(__("Deposit cancelled"));
-		await loadDrops();
-	} catch (err) {
+		if (isElectronMode) {
+			await loadDrops();
+		} else {
+			refreshBrowserList();
+		}
+	} catch (error) {
 		showError(__("Failed to cancel deposit"));
-		console.error("Failed to delete bank drop:", err);
+		console.error("Failed to cancel bank drop:", error);
 	}
 }
 
-async function loadContext() {
-	const shift = posStore.posOpeningShift?.name;
-	if (shift && posStore.profileName) {
-		await paymentStore.fetchCashMovementContext(posStore.profileName, shift);
-	}
-}
+watch(
+	[() => posStore.posOpeningShift?.name, () => posStore.profileName],
+	async ([shift, profileName]) => {
+		if (shift && profileName) {
+			await paymentStore.fetchCashMovementContext(profileName, shift);
+		}
 
-onMounted(async () => {
-	await loadContext();
-	await loadDrops();
-});
+		if (isElectronMode) {
+			await loadDrops();
+		}
+	},
+	{ immediate: true },
+);
 </script>


### PR DESCRIPTION
This pull request introduces a new `BankDropDetailDialog` Vue component to the frontend. This dialog displays detailed information about a bank drop, including amount, posting date, deposit account, reference, company, POS profile, user, and remarks. The dialog is styled and uses several UI components for consistency with the rest of the application.

New feature - Bank Drop Detail Dialog:

* Added a new `BankDropDetailDialog.vue` component that displays detailed information about a selected bank drop, including status, amount, posting date, deposit account, reference, company, POS profile, user, and remarks. The dialog uses UI components such as `Dialog`, `Badge`, and icons for a consistent look and feel.
* Implemented helper functions within the component for formatting status, date, and amount, as well as for determining the dialog title based on available bank drop details.
* Integrated localization support for all displayed labels using the `__` translation function.