### PR TITLE
fix: simplify psutil import handling in utilities.py

### DIFF
--- a/xpos/x_pos/api/utilities.py
+++ b/xpos/x_pos/api/utilities.py
@@ -11,15 +11,11 @@ from pathlib import Path
 from typing import Any
 
 import frappe
+import psutil
 from frappe import _
 from frappe.utils import add_to_date, cstr, flt, get_datetime
 
 from .utils import fetch_sales_person_names, get_item_groups
-
-try:
-	import psutil
-except ImportError:  # pragma: no cover - optional dependency
-	psutil = None
 
 _PSUTIL_MISSING_LOGGED = False
 


### PR DESCRIPTION
This pull request simplifies the import of the `psutil` library in the `xpos/x_pos/api/utilities.py` file by removing the conditional import logic. Now, `psutil` is always imported directly at the top of the file.

Dependency import simplification:

* Changed the import of `psutil` from a try/except block to a standard import, ensuring it is always required and available when the module is loaded (`xpos/x_pos/api/utilities.py`).