### PR TITLE
ref: updated docs related to version-16

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,10 @@ This project follows a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, 
 
 | Dependency       | Version  |
 | ---------------- | -------- |
-| Python           | >= 3.10  |
-| Node.js          | >= 18    |
-| Frappe Framework  | v15      |
-| ERPNext          | v15      |
+| Python           | >= 3.14  |
+| Node.js          | >= 24    |
+| Frappe Framework  | v16      |
+| ERPNext          | v16      |
 
 ### Pre-commit Hooks
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A modern, offline-capable Point of Sale for Frappe & ERPNext**
 
-License: MIT · Frappe v15 · ERPNext v15
+License: MIT · Frappe v16 · ERPNext v16
 
 </div>
 
@@ -117,10 +117,10 @@ X POS is a feature-rich, offline-first Point of Sale application built on Frappe
 
 | Dependency | Version |
 |---|---|
-| Python | >= 3.10 |
-| Frappe Framework | v15 |
-| ERPNext | v15 |
-| Node.js | >= 18 (for builds) |
+| Python | >= 3.14 |
+| Frappe Framework | v16 |
+| ERPNext | v18 |
+| Node.js | >= 24 (for builds) |
 
 ---
 

--- a/docs/features/00-overview.md
+++ b/docs/features/00-overview.md
@@ -39,10 +39,10 @@
 
 | Requirement | Version |
 |---|---|
-| Python | ≥ 3.10 |
-| Frappe Framework | v15 |
-| ERPNext | v15 |
-| Node.js | ≥ 18 |
+| Python | ≥ 3.14 |
+| Frappe Framework | v16 |
+| ERPNext | v16 |
+| Node.js | ≥ 24 |
 
 ---
 


### PR DESCRIPTION
This pull request updates the minimum required versions for core dependencies across documentation and configuration files to ensure compatibility with newer releases of Python, Node.js, Frappe Framework, and ERPNext.

Dependency version updates:

* Increased the minimum required Python version from 3.10 to 3.14 in `README.md`, `CONTRIBUTING.md`, and `docs/features/00-overview.md`.
* Increased the minimum required Node.js version from 18 to 24 in `README.md`, `CONTRIBUTING.md`, and `docs/features/00-overview.md`.
* Updated the required Frappe Framework version from v15 to v16 in `README.md`, `CONTRIBUTING.md`, and `docs/features/00-overview.md`.
* Updated the required ERPNext version from v15 to v16 (and v18 in one instance) in `README.md`, `CONTRIBUTING.md`, and `docs/features/00-overview.md`.