### PR TITLE
chore: update frappe dependency to version 16.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ build-backend = "flit_core.buildapi"
 # package_name = "~=1.1.0"
 
 [tool.bench.frappe-dependencies]
-frappe = ">=15.0.0,<16.0.0"
+frappe = ">=16.0.0,<17.0.0"
 
 [tool.ruff]
 line-length = 110


### PR DESCRIPTION
This pull request updates the `frappe` dependency version in `pyproject.toml` to require version 16.x instead of 15.x.

Dependency update:

* Updated the `frappe` dependency requirement from `>=15.0.0,<16.0.0` to `>=16.0.0,<17.0.0` under `[tool.bench.frappe-dependencies]` in `pyproject.toml`.